### PR TITLE
Add ca-certificates package installation

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,12 @@
+- name: Install Wazuh prerequisites
+  package:
+    name: "{{ package }}"
+    state: latest
+  loop: 
+    - ca-certificates
+  loop_control:
+    loop_var: package
+
 - name: Download Wazuh installation script
   get_url:
     url: "{{ wazuh_install_script_url }}"


### PR DESCRIPTION
On a debian template, the installation fails with a certificate error because this package is not installed.

This commit just add the package before downloading the Wazuh installation script.