### PR TITLE
Add git package in prerequisites

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,7 @@
     state: latest
   loop: 
     - ca-certificates
+    - git
   loop_control:
     loop_var: package
 


### PR DESCRIPTION
git is not installed by default on the debian template, however it is required to dowload socfortress rules.