### PR TITLE
Fixed Requirements for Wazuh Siem Server 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ An Ansible role that runs the Wazuh SIEM on a Linux system. By default, the pass
 
 ## Requirements
 
-None.
+The Wazuh Server Siem must not be Debian 12.
+it works on Ubuntu 22 , Kali-Linux 2024 
 
 ## Role Variables
 


### PR DESCRIPTION
Wazuh Siem Server will have issues when deploying on debian 11,12 os specifically the Web UI or Wazuh Dashboard not appearing or wazuh-dashboard service seemly nuking itself after installation.

However the error can be solved if deployed using Ubuntu 22.04 or Kali Linux 2024